### PR TITLE
Lift phantom lets from deeper, handle execution order issues better

### DIFF
--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -223,6 +223,31 @@ let ccatch (i, ids, e1, e2, dbg) =
 let reset () =
   label_counter := 99
 
+let lift_phantom_lets f exp =
+  let rec lift exp lifted_rev depth =
+    let next_depth = depth + 1 in
+    match exp with
+    | Cop (op, args, dbg) when depth < 4 ->
+      let lifted_rev, args =
+        List.fold_left (fun (lifted_rev, args) arg ->
+            let lifted_rev, arg = lift arg lifted_rev next_depth in
+            lifted_rev, arg :: args)
+          ([], [])
+          (List.rev args)
+      in
+      lifted_rev, Cop (op, args, dbg)
+    | Cphantom_let (var, defining_expr, body) ->
+      lift body ((var, defining_expr) :: lifted_rev) depth
+    | _ -> lifted_rev, exp
+  in
+  let lifted_rev, exp = lift exp [] 0 in
+  let exp = f exp in
+  List.fold_left (fun exp (var, defining_expr) ->
+      Cphantom_let (var, defining_expr, exp))
+    exp
+    lifted_rev
+
+
 let rec map_single_tail f = function
   | Clet (id, exp, body) ->
       let result = map_single_tail f body in
@@ -234,4 +259,9 @@ let rec map_single_tail f = function
       let result = map_single_tail f s2 in
       Csequence (s1, result)
   | body ->
-      f body
+      lift_phantom_lets f body
+
+let map_single_tail2 f exp1 exp2 =
+  map_single_tail (fun exp2 ->
+      map_single_tail (fun exp1 -> f exp1 exp2) exp1)
+    exp2

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -224,6 +224,11 @@ let reset () =
   label_counter := 99
 
 let lift_phantom_lets f exp =
+  (* Unbounded exploration would be linear in the size of the expression,
+     which can lead to a translation pass that becomes quadratic in the size
+     of the original program. Limiting to a fixed depth prevents this problem,
+     and it happens that no existing optimisation looks deeper than 4 nested
+     operations, so no optimisation is lost because of this restriction. *)
   let rec lift exp lifted_rev depth =
     let next_depth = depth + 1 in
     match exp with

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -226,3 +226,10 @@ val map_single_tail : (expression -> expression) -> expression -> expression
     This function will not recurse into any expression that contain
     more than one result expression, meaning the transformation will be
     applied exactly once *)
+
+val map_single_tail2 :
+  (expression -> expression -> expression) ->
+  expression -> expression -> expression
+(** Analog of [map_single_tail] for binary functions.
+    Assumes that the second argument is meant to be evaluated before
+    the first one, and preserves this evaluation order. *)

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -182,9 +182,7 @@ let rec add_int_aux c1 c2 dbg =
   | (_, _) ->
       Cop(Caddi, [c1; c2], dbg)
 and add_int c1 c2 dbg =
-  c1 |> map_single_tail @@ fun c1 ->
-  c2 |> map_single_tail @@ fun c2 ->
-  add_int_aux c1 c2 dbg
+  map_single_tail2 (fun c1 c2 -> add_int_aux c1 c2 dbg) c1 c2
 
 let rec sub_int_aux c1 c2 dbg =
   match (c1, c2) with
@@ -197,9 +195,7 @@ let rec sub_int_aux c1 c2 dbg =
   | (c1, c2) ->
       Cop(Csubi, [c1; c2], dbg)
 and sub_int c1 c2 dbg =
-  c1 |> map_single_tail @@ fun c1 ->
-  c2 |> map_single_tail @@ fun c2 ->
-  sub_int_aux c1 c2 dbg
+  map_single_tail2 (fun c1 c2 -> sub_int_aux c1 c2 dbg) c1 c2
 
 let rec lsl_int_aux c1 c2 dbg =
   match (c1, c2) with
@@ -212,9 +208,7 @@ let rec lsl_int_aux c1 c2 dbg =
   | (_, _) ->
       Cop(Clsl, [c1; c2], dbg)
 and lsl_int c1 c2 dbg =
-  c1 |> map_single_tail @@ fun c1 ->
-  c2 |> map_single_tail @@ fun c2 ->
-  lsl_int_aux c1 c2 dbg
+  map_single_tail2 (fun c1 c2 -> lsl_int_aux c1 c2 dbg) c1 c2
 
 let is_power2 n = n = 1 lsl Misc.log2 n
 
@@ -237,9 +231,7 @@ let rec mul_int_aux c1 c2 dbg =
   | (c1, c2) ->
       Cop(Cmuli, [c1; c2], dbg)
 and mul_int c1 c2 dbg =
-  c1 |> map_single_tail @@ fun c1 ->
-  c2 |> map_single_tail @@ fun c2 ->
-  mul_int_aux c1 c2 dbg
+  map_single_tail2 (fun c1 c2 -> mul_int_aux c1 c2 dbg) c1 c2
 
 let ignore_low_bit_int =
   map_single_tail (function
@@ -522,9 +514,7 @@ let rec div_int_aux c1 c2 is_safe dbg =
                       raise_symbol dbg "caml_exn_Division_by_zero",
                       dbg)))
 and div_int c1 c2 is_safe dbg =
-  c1 |> map_single_tail @@ fun c1 ->
-  c2 |> map_single_tail @@ fun c2 ->
-  div_int_aux c1 c2 is_safe dbg
+  map_single_tail2 (fun c1 c2 -> div_int_aux c1 c2 is_safe dbg) c1 c2
 
 let mod_int c1 c2 is_safe dbg =
   match (c1, c2) with
@@ -567,9 +557,7 @@ let mod_int c1 c2 is_safe dbg =
                       dbg)))
 
 let mod_int c1 c2 is_safe dbg =
-  c1 |> map_single_tail @@ fun c1 ->
-  c2 |> map_single_tail @@ fun c2 ->
-  mod_int c1 c2 is_safe dbg
+  map_single_tail2 (fun c1 c2 -> mod_int c1 c2 is_safe dbg) c1 c2
 
 (* Division or modulo on boxed integers.  The overflow case min_int / -1
    can occur, in which case we force x / -1 = -x and x mod -1 = 0. (PR#5513). *)


### PR DESCRIPTION
This patch brings support for lifting phantom lets deeper inside operations, with code taken from Mark's gdb branch, and makes it a bit easier to think about and handle evaluation order issues when exploring two expressions at once.
For expressions like `(e1; x) + (e2; y)`, your patch switched the evaluation order of `e1` and `e2` (`e2` is expected to be evaluated first for historical reasons and compatibility with bytecode); with this PR, the evaluation order is back to normal.

I still need to think about handling peephole optimisations that match on Clambda terms, but I expect it is much less related to your PR and will likely submit it independently.